### PR TITLE
I106 überprüfen der prozessmetriken in falsche richtung

### DIFF
--- a/frontend/static/content/mapping_metrics_definition.json
+++ b/frontend/static/content/mapping_metrics_definition.json
@@ -85,7 +85,7 @@
       "metrics": {
         "complaints": {
           "name": "Complaints [per month]",
-          "fulfilled_if": ">",
+          "fulfilled_if": "<",
           "max_value": -1,
           "min_value": 0,
           "description_component": "Number of user complaints per month.",
@@ -185,7 +185,7 @@
       "metrics": {
         "time_to_implement_updates": {
           "name": "Implementation time of updates [in days]",
-          "fulfilled_if": ">",
+          "fulfilled_if": "<",
           "max_value": -1,
           "min_value": 0,
           "description_component": "Time to implement post-release updates (average) until they are implemented (in days).",


### PR DESCRIPTION
## Bereich
* Backend
   - Database-Handler
* Database

## Typ
* Testfinding / Bug

## Code Review
- [ ]  @sascha7777

## Funktionale Review
- [x] @prinzpaul 

## Anmerkungen
Fehler wurde lediglich in mappings metric definition gefunden, dieser korrigiert und dei daten neu in die datenbank eingespeist
