### PR TITLE
I128: Min Max Werte für Inputs / Custom Hover Info Boxen

### DIFF
--- a/frontend/static/css/einzelkomponente.css
+++ b/frontend/static/css/einzelkomponente.css
@@ -336,3 +336,7 @@ button, html input[type="button"], input[type="reset"] {
   float: none;
   clear: none;
 }
+
+.icon-popup-fix.info-text-popup::before {
+  margin-right: 24%;
+}

--- a/frontend/static/css/einzelkomponente.css
+++ b/frontend/static/css/einzelkomponente.css
@@ -324,3 +324,15 @@ button, html input[type="button"], input[type="reset"] {
   padding-left: 10px;
   padding-right: 10px;
 }
+
+.metric-entry-element .info-text-popup {
+  display: inline-block;
+  float: left;
+  clear: left;
+}
+
+.icon-popup-fix.info-text-popup {
+  display: block;
+  float: none;
+  clear: none;
+}

--- a/frontend/static/css/process_styles.css
+++ b/frontend/static/css/process_styles.css
@@ -482,31 +482,6 @@ table .process-visualization {
   margin-bottom: 8px;
 }
 
-.info-text-header { position: relative; }
-
-.info-text-header::before {
-  content: attr(tooltip-data);/* print em-space with class text */
-  font-size: 10.5px;
-  display: block;
-  position: absolute;
-  bottom: 100%;
-  background: #000;
-  color: #FFF;
-  padding: 5px;
-  border-radius: 5px;
-  white-space: pre;
-  max-width:none;
-  opacity:0;
-  transition:0.35s ease-out;
-  overflow:hidden;
-  pointer-events: none; /* prevents tooltip from firing on pseudo hover */
-}
-
-.info-text-header:hover::before {
-  opacity:1;
-  bottom: 100%;
-}
-
 .accordion-icon-dropdown-toggle {
   position: absolute;
   font-size: 20px;

--- a/frontend/static/css/styles.css
+++ b/frontend/static/css/styles.css
@@ -473,3 +473,31 @@ td {
 .fa-trash-alt {
     cursor: pointer;
 }
+
+.info-text-popup {
+    position: relative;
+}
+
+.info-text-popup::before {
+    content: attr(tooltip-data);/* print em-space with class text */
+    font-size: 10.5px;
+    right: 10%;
+    display: block;
+    position: absolute;
+    bottom: 100%;
+    background: #000;
+    color: #FFF;
+    padding: 5px;
+    border-radius: 5px;
+    white-space: pre;
+    max-width:none;
+    opacity:0;
+    transition:0.35s ease-out;
+    overflow:hidden;
+    pointer-events: none; /* prevents tooltip from firing on pseudo hover */
+}
+
+.info-text-popup:hover::before {
+    opacity:1;
+    bottom: 100%;
+}

--- a/frontend/static/js/helper.js
+++ b/frontend/static/js/helper.js
@@ -111,16 +111,17 @@ class Helper {
                 let metric = metrics[key];
                 innerHTML += '<div class="metric-entry-element">';
                 innerHTML += ('<label for="availability-metric" class="entry-label">' + metric['name'] + '</label>');
-                innerHTML += '<input type="text" maxLength="256" data-name="availability-metric-1" id="' + key + '"' +
+                innerHTML += '<div><input type="text" maxLength="256" data-name="availability-metric-1" id="' + key + '"' +
                     ' name="availability-metric" class="metric-input textfield"'
                 if (metric['max_value'] === -1) {
                     innerHTML += '" min="' + metric['min_value'] + '"'
                 } else {
                     innerHTML += ' max="' + metric['max_value'] + '" min="' + metric['min_value'] + '"'
                 }
-                innerHTML += ' >';
-                innerHTML += '<img src="images/info.png" loading="lazy" width="35" alt="" title="' +
-                    metric['description_component'] + '\ni.e. ' + metric['example_component'] + '" class="info-icon">';
+                innerHTML += ' ></div>';
+                innerHTML += '<div class="icon-popup-fix info-text-popup" tooltip-data="' +
+                    metric['description_component'] + '\ni.e. ' + metric['example_component'] + '">' +
+                    '<img src="images/info.png" loading="lazy" width="35" alt="" class="info-icon"></div>';
                 innerHTML += '</div>';
             });
 
@@ -138,6 +139,7 @@ class Helper {
         console.log(inputs);
         console.log(inputs[0]);
         for (let i = 0; i < inputs.length; i++) {
+            this.addMinMaxPopup(inputs[i]);
             inputs[i].addEventListener('blur', (event) => {
                 if (!helper.targetAvgIsWithinMinMax(inputs[i]) || inputs[i].value === '') {
                     inputs[i].style.setProperty("border-color", "red", undefined);
@@ -146,6 +148,24 @@ class Helper {
                 }
             });
         }
+    }
+
+    /**
+     * Adds a min max popup to the parent HTMLelement of the given HTMLelement
+     *
+     * @param {HTMLElement} element
+     */
+
+    addMinMaxPopup(element) {
+        let tooltipData;
+        if(element.hasAttribute("min") && element.hasAttribute("max")) {
+            tooltipData = "Min: "+element.getAttribute("min")+" Max: "+element.getAttribute("max");
+        } else {
+            if(element.hasAttribute("min")) tooltipData = "Min: "+element.getAttribute("min");
+            if(element.hasAttribute("max")) tooltipData = "Max: "+element.getAttribute("max")
+        }
+        element.parentElement.classList.add("info-text-popup");
+        element.parentElement.setAttribute("tooltip-data", tooltipData);
     }
 
     /**

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -190,31 +190,31 @@ function createMetricsSection(features, processData) {
         <table class="responsive-table" id="process-feature-table">
             <tr class="table-header">
                 <th class="col-1" name="metric">Metric</th>
-                <th class="col-2 info-text-header" name="average" tooltip-data="The average value for the respective metrics&#xa; across all components in the process.">
+                <th class="col-2 info-text-popup" name="average" tooltip-data="The average value for the respective metrics&#xa; across all components in the process.">
                     Average
                 </th>
-                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="The standard deviation for each metric&#xa; across all components in the process." >
+                <th class="col-3 info-text-popup" name="standard-deviation" tooltip-data="The standard deviation for each metric&#xa; across all components in the process." >
                     Std. Dev.
                 </th>
-                <th class="col-4 info-text-header" name="sum" tooltip-data="The sum for each respective metric&#xa; across all components in the process.">
+                <th class="col-4 info-text-popup" name="sum" tooltip-data="The sum for each respective metric&#xa; across all components in the process.">
                     Sum
                 </th>
-                <th class="col-5 info-text-header" name="min" tooltip-data="The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process.">
+                <th class="col-5 info-text-popup" name="min" tooltip-data="The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process.">
                     Min
                 </th>
-                <th class="col-6 info-text-header" name="max" tooltip-data="The maximum value indicates the largest value for each&#xa; respective metric across all components of the process.">
+                <th class="col-6 info-text-popup" name="max" tooltip-data="The maximum value indicates the largest value for each&#xa; respective metric across all components of the process.">
                     Max
                 </th>
-                <th class="col-7 info-text-header" name="target-min" tooltip-data="The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process.">
+                <th class="col-7 info-text-popup" name="target-min" tooltip-data="The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process.">
                     Target Min
                 </th>
-                <th class="col-8 info-text-header" name="target-max" tooltip-data="The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process.">
+                <th class="col-8 info-text-popup" name="target-max" tooltip-data="The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process.">
                     Target Max
                 </th>
-                <th class="col-9 info-text-header" name="target-avg" tooltip-data="The average, user-entered, Target-value&#xa; for each metric across all components in the process.">
+                <th class="col-9 info-text-popup" name="target-avg" tooltip-data="The average, user-entered, Target-value&#xa; for each metric across all components in the process.">
                     Target Average
                 </th>
-                <th class="col-10 info-text-header" name="target-sum" tooltip-data="The target sum for each metric across&#xa; all components in the process.">
+                <th class="col-10 info-text-popup" name="target-sum" tooltip-data="The target sum for each metric across&#xa; all components in the process.">
                     Target Sum
                 </th>
                 <th class="col-11" name="ampel">Check</th>
@@ -245,6 +245,11 @@ function checkCorrectInputs() {
     names.forEach(element => {
         const inputs = document.getElementsByName(element);
         for (let i = 0; i < inputs.length; i++) {
+            // Adding popup for target avg input -> with min max values if they exist
+            if(element == 'target-average') {
+                helper.addMinMaxPopup(inputs[i]);
+            }
+            // Adding event listener for input check
             inputs[i].addEventListener('blur', (event) => {
                 if (!helper.targetAvgIsWithinMinMax(inputs[i])) {
                     inputs[i].style.setProperty("border-color", "red", undefined);
@@ -291,9 +296,9 @@ function fillMetricRows(metricData, slug, processData) {
                         <td class="col-10" ></td>`;
     let innerHTML_fulfillment = `
                         <td class="col-11" ></td>
-                        <td class="col-12" ><img src="images/info.png" loading="lazy" width="35"
-                        title="` + metricData['description_process'] + `\ni.e. ` + metricData['example_process'] + `"
-                        alt="" class="info-icon"></td>
+                        <td class="col-12" ><div tooltip-data="` + metricData['description_process'] + `\ni.e. ` + metricData['example_process'] + `"
+                         class="info-text-popup"><img class="info-icon" src="images/info.png" loading="lazy" width="35"
+                         ></div></td>
                     </tr>`;
 
     if (uid != null && uid !== -1 && (slug in processData['actual_target_metrics'])) {
@@ -321,9 +326,9 @@ function fillMetricRows(metricData, slug, processData) {
             metric_fulfillment = processData['actual_target_metrics'][slug]['fulfillment'];
             innerHTML_fulfillment = `
                         <td class="col-11" >${helper.renderSmallCircle(metric_fulfillment)}</td>
-                        <td class="col-12" ><img src="images/info.png" loading="lazy" width="35" alt="heyy"
-                         title="` + metricData['description_process'] + `\ni.e. ` + metricData['example_process'] + `"
-                         class="info-icon"></td>
+                        <td class="col-12" ><div tooltip-data="` + metricData['description_process'] + `\ni.e. ` + metricData['example_process'] + `"
+                         class="info-text-popup"><img class="info-icon" src="images/info.png" loading="lazy" width="35"
+                         ></div></td>
                     </tr>`;
         }
     }
@@ -371,7 +376,6 @@ function getMetricRowTarget(innerHTML_target, actual_target_metrics, slug) {
                         <td class="col-8" ><input type="text" name="target-maximum" id = "`+ slug + `" value="`+ targetValues['max'] + `"`;
     innerHTML_target['average'] = `
                         <td class="col-9" ><input type="text" name="target-average" id = "`+ slug + `" value="`+ targetValues['average'] + `"`;
-
     return innerHTML_target;
 }
 
@@ -390,8 +394,12 @@ function getMetricRowTotal(actual_target_metrics) {
 function addMinMaxToInputFields(innerHTML_target, metricData) {
 
     // Rest of the innerHTML_target string
-    if (metricData['min_value'] >= 0) innerHTML_target += ' min="' + metricData['min_value'] + '"';
-    if (metricData['max_value'] >= 0) innerHTML_target += ' max="' + metricData['max_value'] + '"';
+    if (metricData['min_value'] >= 0) {
+        innerHTML_target += ' min="' + metricData['min_value'] + '"';
+    }
+    if (metricData['max_value'] >= 0) {
+        innerHTML_target += ' max="' + metricData['max_value'] + '"';
+    }
 
     innerHTML_target += `></td>`;
 


### PR DESCRIPTION
## Bereich
<!--- Bitte Unzutreffendes streichen -->
* Frontend

## Typ
<!--- Bitte Unzutreffendes streichen -->
* Feature
* Testfinding / Bug

## Code Review
- [x] @NimsaJ150 / @jonathan112358 / @sascha7777

## Funktionale Review
- [x] @Timo-Buecher 

## Anmerkungen
<!--- Falls wichtige Anmerkungen zu machen sind -->
**Änderungen:**

Prozessansicht:
- Hover auf help icon -> Wie bei den Tabellen Headern wird ein custom popup angezeigt
- Hover auf target average -> Min max wird popup mit min & max angezeigt falls es eins gibt, wenn nur min oder nur max dann entsprechend nur min oder max, wenn beides nicht in den attributen ist dann nichts

Komponentenansicht:
- Hover auf help icon -> Custom popup wird angezeigt
- Hover auf metric input -> Min max wird popup mit min & max angezeigt falls es eins gibt, wenn nur min oder nur max dann entsprechend nur min oder max, wenn beides nicht in den attributen ist dann nichts

Generell:
-> Popups werden instant angezeigt
-> Info popup css code ausgelagert in styles.css
-> Div wrapper bei img & input Element hinzugefügt weil das mit dem Popup sonst gar nicht funktioniert -> Es kann sonst kein before Element erstellt werden bei diesen HTML Tags

Closes #128 