### PR TITLE
I109 Auslagern von Tabellenheader Helper Texten (neu)

### DIFF
--- a/frontend/static/content/en.json
+++ b/frontend/static/content/en.json
@@ -79,8 +79,18 @@
             "description": "Description",
             "responsible-person": "Responsible Person",
             "Whats-Riskify": "What's Riskify?",
-            "Loading": "Loading..."
-
+            "Loading": "Loading...",
+            "average": "Average",
+            "standard-deviation": "Std. Dev.",
+            "sum": "Sum",
+            "min": "Min",
+            "max": "Max",
+            "target-min": "Target Min",
+            "target-max": "Target Max",
+            "target-avg": "Target Average",
+            "target-sum": "Target Sum",
+            "check": "Check",
+            "info": "Info"
         }
     }
 }

--- a/frontend/static/content/en.json
+++ b/frontend/static/content/en.json
@@ -79,18 +79,7 @@
             "description": "Description",
             "responsible-person": "Responsible Person",
             "Whats-Riskify": "What's Riskify?",
-            "Loading": "Loading...",
-            "average": "Average",
-            "standard-deviation": "Std. Dev.",
-            "sum": "Sum",
-            "min": "Min",
-            "max": "Max",
-            "target-min": "Target Min",
-            "target-max": "Target Max",
-            "target-avg": "Target Average",
-            "target-sum": "Target Sum",
-            "check": "Check",
-            "info": "Info"
+            "Loading": "Loading..."
         }
     }
 }

--- a/frontend/static/content/process-feature-definition.json
+++ b/frontend/static/content/process-feature-definition.json
@@ -1,0 +1,13 @@
+{
+  "process-feature-table": {
+    "average": "The average value for the respective metrics&#xa; across all components in the process.",
+    "standard-deviation": "The standard deviation for each metric&#xa; across all components in the process.",
+    "sum": "The sum for each respective metric&#xa; across all components in the process.",
+    "min": "The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process.",
+    "max": "The maximum value indicates the largest value for each&#xa; respective metric across all components of the process.",
+    "target-min": "The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process.",
+    "target-max": "The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process.",
+    "target-avg": "The average, user-entered, Target-value&#xa; for each metric across all components in the process.",
+    "target-sum": "The target sum for each metric across&#xa; all components in the process."
+  }
+}

--- a/frontend/static/content/table_header_info.json
+++ b/frontend/static/content/table_header_info.json
@@ -1,13 +1,46 @@
 {
   "headerInfo": {
-    "average": "The average value for the respective metrics&#xa; across all components in the process.",
-    "standard-deviation": "The standard deviation for each metric&#xa; across all components in the process.",
-    "sum": "The sum for each respective metric&#xa; across all components in the process.",
-    "min": "The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process.",
-    "max": "The maximum value indicates the largest value for each&#xa; respective metric across all components of the process.",
-    "target-min": "The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process.",
-    "target-max": "The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process.",
-    "target-avg": "The average, user-entered, Target-value&#xa; for each metric across all components in the process.",
-    "target-sum": "The target sum for each metric across&#xa; all components in the process."
+    "average": {
+      "name": "Average",
+      "helper": "The average value for the respective metrics&#xa; across all components in the process."
+    },
+    "standard-deviation": {
+      "name": "Standard deviation",
+      "helper": "The standard deviation for each metric&#xa; across all components in the process."
+    },
+    "sum": {
+      "name": "Sum",
+      "helper": "The sum for each respective metric&#xa; across all components in the process."
+    },
+    "min": {
+      "name": "Min",
+      "helper": "The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process."
+    },
+    "max": {
+      "name": "Max",
+      "helper": "The maximum value indicates the largest value for each&#xa; respective metric across all components of the process."
+    },
+    "target-min": {
+      "name": "Target Min",
+      "helper": "The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process."
+    },
+    "target-max": {
+      "name": "Target Max",
+      "helper": "The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process."
+    },
+    "target-avg": {
+      "name": "Target Average",
+      "helper": "The average, user-entered, Target-value&#xa; for each metric across all components in the process."
+    },
+    "target-sum": {
+      "name": "Target Sum",
+      "helper": "The target sum for each metric across&#xa; all components in the process."
+    },
+    "info": {
+      "name": "Info"
+    },
+    "check": {
+      "name": "Check"
+    }
   }
 }

--- a/frontend/static/content/table_header_info.json
+++ b/frontend/static/content/table_header_info.json
@@ -1,5 +1,5 @@
 {
-  "process-feature-table": {
+  "headerInfo": {
     "average": "The average value for the respective metrics&#xa; across all components in the process.",
     "standard-deviation": "The standard deviation for each metric&#xa; across all components in the process.",
     "sum": "The sum for each respective metric&#xa; across all components in the process.",

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -19,14 +19,14 @@ function init(json_process = false) {
     getFeatures().then(data => {
         // If page is reloaded (after saving) processes are updated else => page is loaded from databased and entries are prepared
         getTableHeaderInfo().then(tableHeaderInfo => {
-        if (!json_process) {
-                getProcess(data, tableHeaderInfo);
+                if (!json_process) {
+                    getProcess(data, tableHeaderInfo);
 
-        } else {
-            fillDataFields(data, json_process, tableHeaderInfo);
-            loadComponentNames(json_process);
+                } else {
+                    fillDataFields(data, json_process, tableHeaderInfo);
+                    loadComponentNames(json_process);
+                }
             }
-        }
         );
     });
 
@@ -210,36 +210,36 @@ function createMetricsSection(features, processData, tableHeaderInfo) {
         innerHTML += `
         <table class="responsive-table" id="process-feature-table">
             <tr class="table-header">
-                <th class="col-1" name="metric">Metric</th>
-                <th class="col-2 info-text-popup" name="average" tooltip-data="${tableHeaderInfo['average']}">
-                Average
+                <th class="col-1" ></th>
+                <th class="col-2 info-text-popup" tooltip-data="` + tableHeaderInfo['average']['helper'] + `">
+                ` + tableHeaderInfo['average']['name'] + `
                 </th>
-                <th class="col-3 info-text-popup" name="standard-deviation" tooltip-data="${tableHeaderInfo['standard-deviation']}">
-                Std. Dev.
+                <th class="col-3 info-text-popup" tooltip-data="` + tableHeaderInfo['standard-deviation']['helper'] + `">
+                ` + tableHeaderInfo['standard-deviation']['name'] + `
                 </th>
-                <th class="col-4 info-text-popup" name="sum" tooltip-data="${tableHeaderInfo['sum']}">
-                Sum
+                <th class="col-4 info-text-popup" tooltip-data="` + tableHeaderInfo['sum']['helper'] + `">
+                ` + tableHeaderInfo['sum']['name'] + `
                 </th>
-                <th class="col-5 info-text-popup" name="min" tooltip-data="${tableHeaderInfo['min']}">
-                Min
+                <th class="col-5 info-text-popup" tooltip-data="` + tableHeaderInfo['min']['helper'] + `">
+                ` + tableHeaderInfo['min']['name'] + `
                 </th>
-                <th class="col-6 info-text-popup" name="max" tooltip-data="${tableHeaderInfo['max']}">
-                Max
+                <th class="col-6 info-text-popup" tooltip-data="` + tableHeaderInfo['max']['helper'] + `">
+                ` + tableHeaderInfo['max']['name'] + `
                 </th>
-                <th class="col-7 info-text-popup" name="target-min" tooltip-data="${tableHeaderInfo['target-min']}">
-                Target Min
+                <th class="col-7 info-text-popup" tooltip-data="` + tableHeaderInfo['target-min']['helper'] + `">
+                ` + tableHeaderInfo['target-min']['name'] + `
                 </th>
-                <th class="col-8 info-text-popup" name="target-max" tooltip-data="${tableHeaderInfo['target-max']}">
-                Target Max
+                <th class="col-8 info-text-popup" tooltip-data="` + tableHeaderInfo['target-max']['helper'] + `">
+                ` + tableHeaderInfo['target-max']['name'] + `
                 </th>
-                <th class="col-9 info-text-popup" name="target-avg" tooltip-data="${tableHeaderInfo['target-avg']}">
-                Target Average
+                <th class="col-9 info-text-popup" tooltip-data="` + tableHeaderInfo['target-avg']['helper'] + `">
+                ` + tableHeaderInfo['target-avg']['name'] + `
                 </th>
-                <th class="col-10 info-text-popup" name="target-sum" tooltip-data="${tableHeaderInfo['target-sum']}">
-                Target Sum
+                <th class="col-10 info-text-popup" tooltip-data="` + tableHeaderInfo['target-sum']['helper'] + `">
+                ` + tableHeaderInfo['target-sum']['name'] + `
                 </th>
-                <th class="col-11" name="ampel">Check</th>
-                <th class="col-12" name="info">Info</th>
+                <th class="col-11">` + tableHeaderInfo['check']['name'] + `</th>
+                <th class="col-12">` + tableHeaderInfo['info']['name'] + `</th>
             </tr>`;
 
         innerHTML += innerHTML_metric_block;
@@ -267,7 +267,7 @@ function checkCorrectInputs() {
         const inputs = document.getElementsByName(element);
         for (let i = 0; i < inputs.length; i++) {
             // Adding popup for target avg input -> with min max values if they exist
-            if(element == 'target-average') {
+            if (element == 'target-average') {
                 helper.addMinMaxPopup(inputs[i]);
             }
             // Adding event listener for input check

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -212,15 +212,15 @@ function createMetricsSection(features, processData, processFeatures) {
                 <th class="col-1" name="metric" data-i18n="metric"></th>
                 <th class="col-2 info-text-header" name="average" tooltip-data="${processData['average']}" data-i18n="average">
                 </th>
-                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="The standard deviation for each metric&#xa; across all components in the process." data-i18n="standard-deviation">
+                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="${processData['standard-deviation']}" data-i18n="standard-deviation">
                 </th>
-                <th class="col-4 info-text-header" name="sum" tooltip-data="The sum for each respective metric&#xa; across all components in the process." data-i18n="sum">
+                <th class="col-4 info-text-header" name="sum" tooltip-data="${processData['sum']}" data-i18n="sum">
                 </th>
-                <th class="col-5 info-text-header" name="min" tooltip-data="The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process." data-i18n="min">
+                <th class="col-5 info-text-header" name="min" tooltip-data="${processData['min']}" data-i18n="min">
                 </th>
-                <th class="col-6 info-text-header" name="max" tooltip-data="The maximum value indicates the largest value for each&#xa; respective metric across all components of the process." data-i18n="max">
+                <th class="col-6 info-text-header" name="max" tooltip-data="${processData['max']}" data-i18n="max">
                 </th>
-                <th class="col-7 info-text-header" name="target-min" tooltip-data="The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-min">
+                <th class="col-7 info-text-header" name="target-min" tooltip-data="${processData['target-min']}" data-i18n="target-min">
                 </th>
                 <th class="col-8 info-text-header" name="target-max" tooltip-data="The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-max">
                 </th>

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -18,12 +18,12 @@ function init(json_process = false) {
 
     getFeatures().then(data => {
         // If page is reloaded (after saving) processes are updated else => page is loaded from databased and entries are prepared
-        getProcessFeatures().then(processFeatures => {
+        getTableHeaderInfo().then(tableHeaderInfo => {
         if (!json_process) {
-                getProcess(data, processFeatures);
+                getProcess(data, tableHeaderInfo);
 
         } else {
-            fillDataFields(data, json_process, processFeatures);
+            fillDataFields(data, json_process, tableHeaderInfo);
             loadComponentNames(json_process);
             }
         }
@@ -63,13 +63,13 @@ async function getFeatures() {
 /**
  * Get list of process features.
  */
-async function getProcessFeatures() {
+async function getTableHeaderInfo() {
     // Read JSON file
-    return await fetch(base_url + '/content/process-feature-definition.json')
+    return await fetch(base_url + '/content/table_header_info.json')
         .then(response => response.json())
         .then(data => {
-            let features = data['process-feature-table'];
-            return features;
+            let tableHeaderInfo = data['headerInfo'];
+            return tableHeaderInfo;
         });
 }
 
@@ -77,10 +77,10 @@ async function getProcessFeatures() {
 /**
  * Fetches process data from BE.
  * @param features
- * @param processFeatures
+ * @param tableHeaderInfo
  */
 
-function getProcess(features, processFeatures) {
+function getProcess(features, tableHeaderInfo) {
     const url_string = window.location.href;
     const url = new URL(url_string);
     let uid = url.searchParams.get('uid');
@@ -96,14 +96,14 @@ function getProcess(features, processFeatures) {
         }`
 
         helper.http_request("POST", "/process/view", true, post_data, function (processData) {
-            fillDataFields(features, processData, processFeatures);
+            fillDataFields(features, processData, tableHeaderInfo);
             loadComponentNames(processData);
         });
 
     } else {
         // If not, prepare for new component input...
         let processData = {};
-        createMetricsSection(features, processData, processFeatures);
+        createMetricsSection(features, processData, tableHeaderInfo);
         console.log('Entering new process');
     }
 }
@@ -113,15 +113,15 @@ function getProcess(features, processFeatures) {
  *
  * @param {json} features
  * @param {json} processData
- * @param {json} processFeatures
+ * @param {json} tableHeaderInfo
  */
-function fillDataFields(features, processData, processFeatures) {
+function fillDataFields(features, processData, tableHeaderInfo) {
 
     if (processData['success']) {
         // fill description column
         fillDescriptionColumn(processData);
         // create metric/feature toggle area
-        createMetricsSection(features, processData, processFeatures);
+        createMetricsSection(features, processData, tableHeaderInfo);
         //
     } else {
         // Component has not been created/edited successfully
@@ -150,9 +150,9 @@ function fillDescriptionColumn(processData) {
  *
  * @param {json} features
  * @param {json} processData
- * @param {json} processFeatures
+ * @param {json} tableHeaderInfo
  */
-function createMetricsSection(features, processData, processFeatures) {
+function createMetricsSection(features, processData, tableHeaderInfo) {
     document.getElementById('metrics-input-processes').innerHTML = '';
     let featureCount = 0;
     Object.keys(features).forEach(function (key) {
@@ -211,31 +211,31 @@ function createMetricsSection(features, processData, processFeatures) {
         <table class="responsive-table" id="process-feature-table">
             <tr class="table-header">
                 <th class="col-1" name="metric">Metric</th>
-                <th class="col-2 info-text-popup" name="average" tooltip-data="${processFeatures['average']}">
+                <th class="col-2 info-text-popup" name="average" tooltip-data="${tableHeaderInfo['average']}">
                 Average
                 </th>
-                <th class="col-3 info-text-popup" name="standard-deviation" tooltip-data="${processFeatures['standard-deviation']}">
+                <th class="col-3 info-text-popup" name="standard-deviation" tooltip-data="${tableHeaderInfo['standard-deviation']}">
                 Std. Dev.
                 </th>
-                <th class="col-4 info-text-popup" name="sum" tooltip-data="${processFeatures['sum']}">
+                <th class="col-4 info-text-popup" name="sum" tooltip-data="${tableHeaderInfo['sum']}">
                 Sum
                 </th>
-                <th class="col-5 info-text-popup" name="min" tooltip-data="${processFeatures['min']}">
+                <th class="col-5 info-text-popup" name="min" tooltip-data="${tableHeaderInfo['min']}">
                 Min
                 </th>
-                <th class="col-6 info-text-popup" name="max" tooltip-data="${processFeatures['max']}">
+                <th class="col-6 info-text-popup" name="max" tooltip-data="${tableHeaderInfo['max']}">
                 Max
                 </th>
-                <th class="col-7 info-text-popup" name="target-min" tooltip-data="${processFeatures['target-min']}">
+                <th class="col-7 info-text-popup" name="target-min" tooltip-data="${tableHeaderInfo['target-min']}">
                 Target Min
                 </th>
-                <th class="col-8 info-text-popup" name="target-max" tooltip-data="${processFeatures['target-max']}">
+                <th class="col-8 info-text-popup" name="target-max" tooltip-data="${tableHeaderInfo['target-max']}">
                 Target Max
                 </th>
-                <th class="col-9 info-text-popup" name="target-avg" tooltip-data="${processFeatures['target-avg']}">
+                <th class="col-9 info-text-popup" name="target-avg" tooltip-data="${tableHeaderInfo['target-avg']}">
                 Target Average
                 </th>
-                <th class="col-10 info-text-popup" name="target-sum" tooltip-data="${processFeatures['target-sum']}">
+                <th class="col-10 info-text-popup" name="target-sum" tooltip-data="${tableHeaderInfo['target-sum']}">
                 Target Sum
                 </th>
                 <th class="col-11" name="ampel">Check</th>

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -18,12 +18,16 @@ function init(json_process = false) {
 
     getFeatures().then(data => {
         // If page is reloaded (after saving) processes are updated else => page is loaded from databased and entries are prepared
+        getProcessFeatures().then(processFeatures => {
         if (!json_process) {
-            getProcess(data);
+                getProcess(data, processFeatures);
+
         } else {
-            fillDataFields(data, json_process);
+            fillDataFields(data, json_process, processFeatures);
             loadComponentNames(json_process);
+            }
         }
+        );
     });
 
 }
@@ -57,11 +61,25 @@ async function getFeatures() {
 }
 
 /**
+ * Get list of process features.
+ */
+async function getProcessFeatures() {
+    // Read JSON file
+    return await fetch(base_url + '/content/process-feature-definition.json')
+        .then(response => response.json())
+        .then(data => {
+            let features = data['process-feature-table'];
+            return features;
+        });
+}
+
+
+/**
  * Fetches process data from BE.
  * @param features
  */
 
-function getProcess(features) {
+function getProcess(features, processFeatures) {
     const url_string = window.location.href;
     const url = new URL(url_string);
     let uid = url.searchParams.get('uid');
@@ -94,14 +112,15 @@ function getProcess(features) {
  *
  * @param {json} features
  * @param {json} processData
+ * @param {json} processFeatures
  */
-function fillDataFields(features, processData) {
+function fillDataFields(features, processData, processFeatures) {
 
     if (processData['success']) {
         // fill description column
         fillDescriptionColumn(processData);
         // create metric/feature toggle area
-        createMetricsSection(features, processData);
+        createMetricsSection(features, processData, processFeatures);
         //
     } else {
         // Component has not been created/edited successfully
@@ -130,8 +149,9 @@ function fillDescriptionColumn(processData) {
  *
  * @param {json} features
  * @param {json} processData
+ * @param {json} processFeatures
  */
-function createMetricsSection(features, processData) {
+function createMetricsSection(features, processData, processFeatures) {
     document.getElementById('metrics-input-processes').innerHTML = '';
     let featureCount = 0;
     Object.keys(features).forEach(function (key) {
@@ -189,36 +209,27 @@ function createMetricsSection(features, processData) {
         innerHTML += `
         <table class="responsive-table" id="process-feature-table">
             <tr class="table-header">
-                <th class="col-1" name="metric">Metric</th>
-                <th class="col-2 info-text-header" name="average" tooltip-data="The average value for the respective metrics&#xa; across all components in the process.">
-                    Average
+                <th class="col-1" name="metric" data-i18n="metric"></th>
+                <th class="col-2 info-text-header" name="average" tooltip-data="${processData['average']}" data-i18n="average">
                 </th>
-                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="The standard deviation for each metric&#xa; across all components in the process." >
-                    Std. Dev.
+                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="The standard deviation for each metric&#xa; across all components in the process." data-i18n="standard-deviation">
                 </th>
-                <th class="col-4 info-text-header" name="sum" tooltip-data="The sum for each respective metric&#xa; across all components in the process.">
-                    Sum
+                <th class="col-4 info-text-header" name="sum" tooltip-data="The sum for each respective metric&#xa; across all components in the process." data-i18n="sum">
                 </th>
-                <th class="col-5 info-text-header" name="min" tooltip-data="The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process.">
-                    Min
+                <th class="col-5 info-text-header" name="min" tooltip-data="The minimum value specifies the smallest value for each&#xa; respective metric across all components in the process." data-i18n="min">
                 </th>
-                <th class="col-6 info-text-header" name="max" tooltip-data="The maximum value indicates the largest value for each&#xa; respective metric across all components of the process.">
-                    Max
+                <th class="col-6 info-text-header" name="max" tooltip-data="The maximum value indicates the largest value for each&#xa; respective metric across all components of the process." data-i18n="max">
                 </th>
-                <th class="col-7 info-text-header" name="target-min" tooltip-data="The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process.">
-                    Target Min
+                <th class="col-7 info-text-header" name="target-min" tooltip-data="The minimum target average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-min">
                 </th>
-                <th class="col-8 info-text-header" name="target-max" tooltip-data="The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process.">
-                    Target Max
+                <th class="col-8 info-text-header" name="target-max" tooltip-data="The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-max">
                 </th>
-                <th class="col-9 info-text-header" name="target-avg" tooltip-data="The average, user-entered, Target-value&#xa; for each metric across all components in the process.">
-                    Target Average
+                <th class="col-9 info-text-header" name="target-avg" tooltip-data="The average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-avg">
                 </th>
-                <th class="col-10 info-text-header" name="target-sum" tooltip-data="The target sum for each metric across&#xa; all components in the process.">
-                    Target Sum
+                <th class="col-10 info-text-header" name="target-sum" tooltip-data="The target sum for each metric across&#xa; all components in the process." data-i18n="target-sum">
                 </th>
-                <th class="col-11" name="ampel">Check</th>
-                <th class="col-12" name="info">Info</th>
+                <th class="col-11" name="ampel" data-i18n="check"></th>
+                <th class="col-12" name="info" data-i18n="info"></th>
             </tr>`;
 
         innerHTML += innerHTML_metric_block;

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -279,9 +279,8 @@ function checkCorrectInputs() {
                     inputs[i].style.removeProperty("border-color");
                 }
             });
-        
+        }
     });
-
 }
 
 /**

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -95,14 +95,14 @@ function getProcess(features, processFeatures) {
         }`
 
         helper.http_request("POST", "/process/view", true, post_data, function (processData) {
-            fillDataFields(features, processData);
+            fillDataFields(features, processData, processFeatures);
             loadComponentNames(processData);
         });
 
     } else {
         // If not, prepare for new component input...
         let processData = {};
-        createMetricsSection(features, processData);
+        createMetricsSection(features, processData, processFeatures);
         console.log('Entering new process');
     }
 }
@@ -205,31 +205,41 @@ function createMetricsSection(features, processData, processFeatures) {
         innerHTML += '<nav class="dropdown-list" data-collapsed="true">';
         innerHTML += '<div class="features-columns">';
 
+        console.log(processFeatures);
         // Table Headers
         innerHTML += `
         <table class="responsive-table" id="process-feature-table">
             <tr class="table-header">
                 <th class="col-1" name="metric" data-i18n="metric"></th>
-                <th class="col-2 info-text-header" name="average" tooltip-data="${processData['average']}" data-i18n="average">
+                <th class="col-2 info-text-header" name="average" tooltip-data="${processFeatures['average']}">
+                Average
                 </th>
-                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="${processData['standard-deviation']}" data-i18n="standard-deviation">
+                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="${processFeatures['standard-deviation']}">
+                Std. Dev.
                 </th>
-                <th class="col-4 info-text-header" name="sum" tooltip-data="${processData['sum']}" data-i18n="sum">
+                <th class="col-4 info-text-header" name="sum" tooltip-data="${processFeatures['sum']}">
+                Sum
                 </th>
-                <th class="col-5 info-text-header" name="min" tooltip-data="${processData['min']}" data-i18n="min">
+                <th class="col-5 info-text-header" name="min" tooltip-data="${processFeatures['min']}">
+                Min
                 </th>
-                <th class="col-6 info-text-header" name="max" tooltip-data="${processData['max']}" data-i18n="max">
+                <th class="col-6 info-text-header" name="max" tooltip-data="${processFeatures['max']}">
+                Max
                 </th>
-                <th class="col-7 info-text-header" name="target-min" tooltip-data="${processData['target-min']}" data-i18n="target-min">
+                <th class="col-7 info-text-header" name="target-min" tooltip-data="${processFeatures['target-min']}">
+                Target Min
                 </th>
-                <th class="col-8 info-text-header" name="target-max" tooltip-data="The maximum target average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-max">
+                <th class="col-8 info-text-header" name="target-max" tooltip-data="${processFeatures['target-max']}">
+                Target Max
                 </th>
-                <th class="col-9 info-text-header" name="target-avg" tooltip-data="The average, user-entered, Target-value&#xa; for each metric across all components in the process." data-i18n="target-avg">
+                <th class="col-9 info-text-header" name="target-avg" tooltip-data="${processFeatures['target-avg']}">
+                Target Avg
                 </th>
-                <th class="col-10 info-text-header" name="target-sum" tooltip-data="The target sum for each metric across&#xa; all components in the process." data-i18n="target-sum">
+                <th class="col-10 info-text-header" name="target-sum" tooltip-data="${processFeatures['target-sum']}">
+                Target Sum
                 </th>
-                <th class="col-11" name="ampel" data-i18n="check"></th>
-                <th class="col-12" name="info" data-i18n="info"></th>
+                <th class="col-11" name="ampel">Check</th>
+                <th class="col-12" name="info">Info</th>
             </tr>`;
 
         innerHTML += innerHTML_metric_block;

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -211,31 +211,31 @@ function createMetricsSection(features, processData, processFeatures) {
         <table class="responsive-table" id="process-feature-table">
             <tr class="table-header">
                 <th class="col-1" name="metric">Metric</th>
-                <th class="col-2 info-text-header" name="average" tooltip-data="${processFeatures['average']}">
+                <th class="col-2 info-text-popup" name="average" tooltip-data="${processFeatures['average']}">
                 Average
                 </th>
-                <th class="col-3 info-text-header" name="standard-deviation" tooltip-data="${processFeatures['standard-deviation']}">
+                <th class="col-3 info-text-popup" name="standard-deviation" tooltip-data="${processFeatures['standard-deviation']}">
                 Std. Dev.
                 </th>
-                <th class="col-4 info-text-header" name="sum" tooltip-data="${processFeatures['sum']}">
+                <th class="col-4 info-text-popup" name="sum" tooltip-data="${processFeatures['sum']}">
                 Sum
                 </th>
-                <th class="col-5 info-text-header" name="min" tooltip-data="${processFeatures['min']}">
+                <th class="col-5 info-text-popup" name="min" tooltip-data="${processFeatures['min']}">
                 Min
                 </th>
-                <th class="col-6 info-text-header" name="max" tooltip-data="${processFeatures['max']}">
+                <th class="col-6 info-text-popup" name="max" tooltip-data="${processFeatures['max']}">
                 Max
                 </th>
-                <th class="col-7 info-text-header" name="target-min" tooltip-data="${processFeatures['target-min']}">
+                <th class="col-7 info-text-popup" name="target-min" tooltip-data="${processFeatures['target-min']}">
                 Target Min
                 </th>
-                <th class="col-8 info-text-header" name="target-max" tooltip-data="${processFeatures['target-max']}">
+                <th class="col-8 info-text-popup" name="target-max" tooltip-data="${processFeatures['target-max']}">
                 Target Max
                 </th>
-                <th class="col-9 info-text-header" name="target-avg" tooltip-data="${processFeatures['target-avg']}">
+                <th class="col-9 info-text-popup" name="target-avg" tooltip-data="${processFeatures['target-avg']}">
                 Target Average
                 </th>
-                <th class="col-10 info-text-header" name="target-sum" tooltip-data="${processFeatures['target-sum']}">
+                <th class="col-10 info-text-popup" name="target-sum" tooltip-data="${processFeatures['target-sum']}">
                 Target Sum
                 </th>
                 <th class="col-11" name="ampel">Check</th>

--- a/frontend/static/js/process-editor.js
+++ b/frontend/static/js/process-editor.js
@@ -77,6 +77,7 @@ async function getProcessFeatures() {
 /**
  * Fetches process data from BE.
  * @param features
+ * @param processFeatures
  */
 
 function getProcess(features, processFeatures) {
@@ -205,7 +206,6 @@ function createMetricsSection(features, processData, processFeatures) {
         innerHTML += '<nav class="dropdown-list" data-collapsed="true">';
         innerHTML += '<div class="features-columns">';
 
-        console.log(processFeatures);
         // Table Headers
         innerHTML += `
         <table class="responsive-table" id="process-feature-table">


### PR DESCRIPTION
## Bereich
* Frontend

## Typ
* Sonstiges: Cleanup

## Code Review
- [ ] @NimsaJ150 

## Funktionale Review
- [ ] @tomhinzmann

## Anmerkungen
Ersetzt PR: https://github.com/Praxisprojekt2021/praxisprojekt/pull/122
Fix des Issues: https://github.com/Praxisprojekt2021/praxisprojekt/issues/109
("Tabellen Header Helper Texte auf der Prozess Ansicht stehen derzeit statisch im Code und sollten in ein entsprechendes (vermutlich neues) json file ausgelagert werden.")